### PR TITLE
Add DIC autoconfiguration possibility for modern containers

### DIFF
--- a/src/ServiceContainer/ContextServiceExtension.php
+++ b/src/ServiceContainer/ContextServiceExtension.php
@@ -96,6 +96,13 @@ final class ContextServiceExtension implements Extension
             $this->crossContainerProcessor->process($scenarioContainer);
         }
 
+        // This feature was introduced only in symfony/dependency-injection v3.3
+        // So we are adding the feature for modern containers and leaving as-is for older ones
+        if (method_exists($scenarioContainer, 'registerForAutoconfiguration')) {
+            $scenarioContainer->registerForAutoconfiguration(\Behat\Behat\Context\Context::class)
+                ->addTag(ContextRegistryPass::CONTEXT_SERVICE_TAG);
+        }
+
         $scenarioContainer->addCompilerPass(new ContextRegistryPass($container->getDefinition('fob_context_service.context_registry')));
         $scenarioContainer->compile();
     }

--- a/src/ServiceContainer/Scenario/ContextRegistryPass.php
+++ b/src/ServiceContainer/Scenario/ContextRegistryPass.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 final class ContextRegistryPass implements CompilerPassInterface
 {
+    const CONTEXT_SERVICE_TAG = 'fob.context_service';
+
     /**
      * @var Definition
      */
@@ -40,7 +42,7 @@ final class ContextRegistryPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        $taggedServices = $container->findTaggedServiceIds('fob.context_service');
+        $taggedServices = $container->findTaggedServiceIds(self::CONTEXT_SERVICE_TAG);
 
         foreach ($taggedServices as $id => $tags) {
             $this->contextRegistryDefinition->addMethodCall(


### PR DESCRIPTION
With Container autoconfiguration in Symfony 3.3, tagging the context services can be a thing from the past.

With this code changes, when you have container 3.3+ (older ones are unaffected since they don't have this feature), and you have autoconfig enabled, all services implementing Behat Context interface will be auto-tagged for you.

This allows for minimal service configuration like this one:
```
services:
    _defaults:
        autowire: true
        autoconfigure: true
        public: true

    Foo\Behat\:
        resource: '../../Context'
```
(provided your services auto-wire nicely)