### PR TITLE
Symfony4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,13 @@ install:
 script:
     - composer validate --strict
 
-    - vendor/bin/ecs check src spec
-
     - vendor/bin/phpspec run --format dot -vvv --no-interaction
     - vendor/bin/behat --strict -vvv --no-interaction
+
+jobs:
+    include:
+        -   stage: Code Standard Checker
+            php: 7.1
+
+            script:
+                - vendor/bin/ecs check src spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
     - 7.1
     - 7.2
 
+env:
+    matrix:
+        - PREFER_LOWEST="--prefer-lowest"
+        - PREFER_LOWEST=""
+
 cache:
     directories:
         - vendor
@@ -12,7 +17,7 @@ before_install:
     - phpenv config-rm xdebug.ini || true
 
 install:
-    - composer update --prefer-dist
+    - composer update --prefer-dist $PREFER_LOWEST
 
 script:
     - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1",
 
         "behat/behat": "^3.1",
-        "symfony/dependency-injection": "^3.0"
+        "symfony/dependency-injection": "^3.0|^4.0"
     },
     "require-dev": {
         "friends-of-behat/cross-container-extension": "^1.0",


### PR DESCRIPTION
Fixes #19 

The only problem I encounter was related to `nette/utils` which uses `object` class which is forbidden for php 7.2. I had problems to force usage a proper version of library and make a build green, so I decide that I will just remove this run. Tests are green, so we should not block Symfony4 support because of coding standard check. But probably it could be done cleaner.

Related threads:
Reported issue: https://github.com/nette/utils/issues/146
Release that should fix it: https://github.com/nette/utils/releases/tag/v2.4.8
My attempts to make it work: https://travis-ci.org/lchrusciel/ContextServiceExtension/branches
